### PR TITLE
リリースノートをRSS経由から表示

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "prettier.jsxBracketSameLine": true,
-    "prettier.jsxSingleQuote": true
+    "prettier.jsxSingleQuote": true,
+    "editor.formatOnSave": true
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "dependencies": {
     "@material-ui/core": "^4.2.1",
     "@material-ui/icons": "^4.2.1",
+    "axios": "^0.19.2",
+    "dayjs": "^1.8.18",
     "intersection-observer": "^0.11.0",
     "mobile-device-detect": "^0.2.3",
     "react": "^16.8.6",
@@ -14,7 +16,8 @@
     "react-router-dom": "^5.0.0",
     "react-scripts": "^3.0.1",
     "react-spring": "^8.0.27",
-    "styled-components": "^4.3.2"
+    "styled-components": "^4.3.2",
+    "xml-js": "^1.6.11"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -3,13 +3,13 @@ import { BrowserRouter as Router, Route } from "react-router-dom";
 import { withStyles, createMuiTheme } from "@material-ui/core/styles";
 import { ThemeProvider as MaterialUIThemeProvider } from "@material-ui/styles";
 import 'intersection-observer';
-import styled, { ThemeProvider } from "styled-components";
-import IconButton from "@material-ui/core/IconButton";
+import { ThemeProvider } from "styled-components";
+
 import Top from "./components/pages/Top";
 import Tos from "./components/pages/Tos";
 import Policy from "./components/pages/Policy";
-import icon from "./images/icon.png";
-import github from "./images/github.png";
+import Information from './components/pages/Information';
+import Header from "./components/organisms/Header/Bar"
 import theme from "./theme";
 
 const uiTheme = createMuiTheme({
@@ -42,27 +42,12 @@ class App extends Component {
         <MaterialUIThemeProvider theme={uiTheme}>
           <ThemeProvider theme={theme}>
             <div className={classes.root}>
-              <AppBar position="static" color="default">
-                <IconButton href="https://peperomia.app">
-                  <img src={icon} height="30" alt="icon" />
-                </IconButton>
-                <IconButton
-                  href="https://github.com/wheatandcat/Peperomia"
-                  target="_blank"
-                  style={{}}
-                >
-                  <img
-                    src={github}
-                    height="25"
-                    alt="github"
-                    style={{ right: 0 }}
-                  />
-                </IconButton>
-              </AppBar>
-              <div style={{ backgroundColor: "#28AEB2", height: "100%" }}>
+              <Header />
+              <div style={{ backgroundColor: '#28AEB2', height: '100%' }}>
                 <Route path="/" exact component={Top} />
                 <Route path="/tos" exact component={Tos} />
                 <Route path="/policy" exact component={Policy} />
+                <Route path="/information" exact component={Information} />
               </div>
             </div>
           </ThemeProvider>
@@ -72,11 +57,7 @@ class App extends Component {
   }
 }
 
-const AppBar = styled.div`
-  display: flex;
-  justify-content: space-between;
-  background-color: ${props => props.theme.color.main};
-  height: 55px;
-`;
 
 export default withStyles(styles)(App);
+
+

--- a/src/components/organisms/Header/Bar.jsx
+++ b/src/components/organisms/Header/Bar.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import 'intersection-observer';
+import styled from 'styled-components';
+import { withStyles } from '@material-ui/core/styles';
+import { blue } from '@material-ui/core/colors';
+import Fab from '@material-ui/core/Fab';
+import IconButton from '@material-ui/core/IconButton';
+import Button from '@material-ui/core/Button';
+import { Link } from 'react-router-dom';
+import icon from '../../../images/icon.png';
+import github from '../../../images/github.png';
+
+export default () => {
+  return (
+    <AppBar position="static" color="default">
+      <IconButton href="https://peperomia.app">
+        <img src={icon} height="30" alt="icon" />
+      </IconButton>
+      <ButtonContainer>
+        <RouteLink to="/information">
+          <ColorButton variant="contained" color="primary" to="/information">
+            リリースノート
+          </ColorButton>
+        </RouteLink>
+        <Fab size="small">
+          <IconButton
+            href="https://github.com/wheatandcat/Peperomia"
+            target="_blank"
+          >
+            <img src={github} height="25" alt="github" style={{ right: 0 }} />
+          </IconButton>
+        </Fab>
+      </ButtonContainer>
+    </AppBar>
+  );
+};
+
+const ColorButton = withStyles((theme) => ({
+  root: {
+    color: theme.palette.getContrastText(blue[500]),
+    backgroundColor: blue[500],
+    '&:hover': {
+      backgroundColor: blue[700],
+    },
+  },
+}))(Button);
+
+const AppBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  background-color: ${(props) => props.theme.color.main};
+  height: 55px;
+`;
+
+const RouteLink = styled(Link)`
+  text-decoration: none;
+`;
+
+const ButtonContainer = styled.div`
+  button {
+    margin: 0.25rem 0.5rem;
+  }
+`;

--- a/src/components/pages/Information.jsx
+++ b/src/components/pages/Information.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import styled from 'styled-components';
+import Divider from '@material-ui/core/Divider';
+import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
+import 'dayjs/locale/ja';
+import useRss from '../../hooks/useRss';
+
+dayjs.extend(advancedFormat);
+
+export default () => {
+  const rss = useRss();
+  console.log(rss);
+
+  return (
+    <>
+      <Title>リリースノート</Title>
+      <Root>
+        <Inner>
+          {rss.map((v, index) => (
+            <div key={index}>
+              <LinkCard>
+                <DateText>
+                  {dayjs(v.pubDate._text).format('YYYY-MM-DD')}
+                </DateText>
+                <BlogTitle>
+                  <a
+                    href={v.link._text}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    {v.title._text}
+                  </a>
+                </BlogTitle>
+              </LinkCard>
+              <Divider />
+            </div>
+          ))}
+        </Inner>
+      </Root>
+    </>
+  );
+};
+
+const Title = styled.div`
+  color: ${(props) => props.theme.color.white};
+  background-color: ${(props) => props.theme.color.main};
+  text-align: center;
+  font-size: 28px;
+  font-weight: bold;
+  height: 100px;
+  display: flex;
+  justify-content: center;
+  padding-top: 3rem;
+`;
+
+const Root = styled.div`
+  background-color: ${(props) => props.theme.color.white};
+  width: 100%;
+  height: 100%;
+  padding-top: 2rem;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Inner = styled.div`
+  width: 100%;
+  max-width: 700px;
+`;
+
+const LinkCard = styled.div`
+  display: flex;
+  padding: 1rem;
+
+  @media screen and (max-width: 767px) {
+    display: block;
+  }
+`;
+
+const DateText = styled.div`
+  color: ${(props) => props.theme.color.gray};
+  font-size: 14px;
+  padding: 0 1rem;
+  padding-top: 0.4rem;
+
+  @media screen and (max-width: 767px) {
+    padding: 0;
+  }
+`;
+
+const BlogTitle = styled.div`
+  font-size: 18px;
+  font-weight: bold;
+
+  a {
+    text-decoration: none;
+    color: ${(props) => props.theme.color.main};
+
+    :link {
+      color: ${(props) => props.theme.color.main};
+    }
+
+    :visited {
+      color: ${(props) => props.theme.color.gray};
+    }
+  }
+`;

--- a/src/components/pages/Policy.jsx
+++ b/src/components/pages/Policy.jsx
@@ -12,8 +12,8 @@ export default class extends Component {
           marginBottom: '50px',
         }}
       >
-        <div class="wrapKOPIPE">
-          <div class="wrapHINAGATA">
+        <div className="wrapKOPIPE">
+          <div className="wrapHINAGATA">
             <h1>プライバシーポリシー</h1>
             <p style={{ paddingLeft: '5px' }}>
               ペペロミア（以下，「当社」といいます。）は，本アプリ上で提供するサービス（以下,「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。
@@ -155,7 +155,7 @@ export default class extends Component {
               </li>
             </ol>
 
-            <p class="tR">以上</p>
+            <p className="tR">以上</p>
           </div>
         </div>
       </div>

--- a/src/components/pages/Tos.jsx
+++ b/src/components/pages/Tos.jsx
@@ -206,7 +206,7 @@ export default class extends Component {
               </li>
             </ol>
 
-            <p class="tR">以上</p>
+            <p className="tR">以上</p>
           </div>
         </div>
       </div>

--- a/src/hooks/useRss.js
+++ b/src/hooks/useRss.js
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import convert from 'xml-js';
+
+// Hook
+function useRss() {
+  const [rss, setRss] = useState([]);
+
+  const fetchRss = async () => {
+    const res = await axios.get(
+      'https://www.wheatandcat.me/rss/category/%E3%83%AA%E3%83%AA%E3%83%BC%E3%82%B9%E3%83%8E%E3%83%BC%E3%83%88'
+    );
+    const data = convert.xml2js(res.data, {
+      compact: true,
+      ignoreDeclaration: true,
+    });
+
+    setRss(data.rss.channel.item || []);
+  };
+
+  useEffect(() => {
+    fetchRss();
+  }, []);
+
+  return rss;
+}
+
+export default useRss;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,6 +2219,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 axobject-query@^2.0.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -3603,10 +3610,22 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+dayjs@^1.8.18:
+  version "1.8.30"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.30.tgz#d3b314d3ccdc179015d915fd3c6e14422c026378"
+  integrity sha512-5s5IGuP5bVvIbOWkEDcfmXsUj24fZW1NMHVVSdSFF/kW8d+alZcI9SpBKC+baEyBe+z3fUp17y75ulstv5swUw==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
@@ -4684,6 +4703,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 follow-redirects@^1.0.0:
   version "1.12.1"
@@ -11117,6 +11143,13 @@ ws@^6.1.2, ws@^6.2.1:
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
+
+xml-js@^1.6.11:
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/xml-js/-/xml-js-1.6.11.tgz#927d2f6947f7f1c19a316dd8eea3614e8b18f8e9"
+  integrity sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==
+  dependencies:
+    sax "^1.2.4"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## 関連 issue

- fixes #6

## 対応内容

<img width="812" alt="スクリーンショット 2020-07-22 19 12 00" src="https://user-images.githubusercontent.com/19209314/88165619-efbfdd00-cc50-11ea-97e0-db294ea5c413.png">

 - リリースノートをRSS経由から表示する画面を追加

## 開発用メモ
無し

